### PR TITLE
Rename localconfigs to localconfig in tests

### DIFF
--- a/tests/database.py
+++ b/tests/database.py
@@ -13,7 +13,7 @@ from components.db import LIBRARIES
 from components.dbc import DefaultDatabaseProvider
 
 try:
-    from localconfig import localconfigs
+    from localconfig import localconfig
 except ImportError:
     print("Unit tests require a local database configuration to be defined.")
     sys.exit(1)
@@ -23,7 +23,7 @@ class TestDatabaseCreation(unittest.TestCase):
     pass
     # Commented out to avoid the test harness from deleting your database.
     # def test_creation_deletion(self):
-    # db = DefaultDatabaseProvider(localconfigs['Database'])
+    # db = DefaultDatabaseProvider(localconfig['Database'])
     # db.check_database()
     # db.delete_database()
 
@@ -31,7 +31,7 @@ class TestDatabaseCreation(unittest.TestCase):
 class TestDatabaeQueries(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.db = DefaultDatabaseProvider(localconfigs['Database'])
+        cls.db = DefaultDatabaseProvider(localconfig['Database'])
         cls.db.check_database()
 
     def testLibraries(self):

--- a/tests/functionality.py
+++ b/tests/functionality.py
@@ -20,7 +20,7 @@ from apis.phabricator import DefaultPhabricatorProvider
 from tests.mock_commandprovider import TestCommandProvider
 
 try:
-    from localconfig import localconfigs
+    from localconfig import localconfig
 except ImportError:
     print("Unit tests require a local database configuration to be defined.")
     sys.exit(1)
@@ -91,7 +91,7 @@ class TestCommandRunner(unittest.TestCase):
         configs = {
             'General': {'env': 'dev'},
             'Command': {'test_mappings': COMMAND_MAPPINGS},
-            'Database': localconfigs['Database'],
+            'Database': localconfig['Database'],
             'Vendor': {},
             'Bugzilla': {},
             'Mercurial': {},


### PR DESCRIPTION
I didn't catch this in my review and misattributed the test failures to changes to the CI config that were in the main branch but not in the PR.

This picks up the change to `localconfig.py.example` in the tests as well (be sure to update your own localconfig.py as well)