### PR TITLE
Add timestamp from mach vendor to bug title

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -150,7 +150,7 @@ class Updatebot:
     # ====================================================================
 
     def _process_library(self, library):
-        new_version = self.vendorProvider.check_for_update(library)
+        new_version, timestamp = self.vendorProvider.check_for_update(library)
         if not new_version:
             self.logger.log("Processing %s but no new version was found." % library.shortname, level=LogLevel.Info)
             return
@@ -162,13 +162,13 @@ class Updatebot:
             self._process_existing_job(library, existing_job)
         else:
             self.logger.log("%s is a brand new revision to updatebot" % (new_version), level=LogLevel.Info)
-            self._process_new_job(library, new_version)
+            self._process_new_job(library, new_version, timestamp)
 
     # ====================================================================
 
     @logEntryExit
-    def _process_new_job(self, library, new_version):
-        bugzilla_id = self.bugzillaProvider.file_bug(library, new_version)
+    def _process_new_job(self, library, new_version, timestamp):
+        bugzilla_id = self.bugzillaProvider.file_bug(library, new_version, timestamp)
 
         status = None
         try:

--- a/components/bugzilla.py
+++ b/components/bugzilla.py
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from dateutil.parser import parse
 
 from apis.bugzilla_api import fileBug, commentOnBug
 from components.providerbase import BaseProvider, INeedsLoggingProvider
@@ -82,9 +83,14 @@ class BugzillaProvider(BaseProvider, INeedsLoggingProvider):
                 assert ('url' in self.config) or (self.config['General']['env'] in ["dev", "prod"]), "No bugzilla url provided, and unknown operating environment"
 
     @logEntryExit
-    def file_bug(self, library, new_release_version):
-        summary = "Update %s to new version %s" % (
-            library.shortname, new_release_version)
+    def file_bug(self, library, new_release_version, release_timestamp):
+        try:
+            release_timestamp = parse(release_timestamp).strftime('%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            pass
+
+        summary = "Update %s to new version %s from %s" % (
+            library.shortname, new_release_version, release_timestamp)
         description = ""
         severity = "normal" if self.config['General']['env'] == "dev" else "S3"
 

--- a/components/mach_vendor.py
+++ b/components/mach_vendor.py
@@ -12,7 +12,7 @@ class VendorProvider(BaseProvider, INeedsCommandProvider, INeedsLoggingProvider)
 
     @logEntryExit
     def check_for_update(self, library):
-        return self.run(["./mach", "vendor", "--check-for-update", library.yaml_path]).stdout.decode().strip()
+        return self.run(["./mach", "vendor", "--check-for-update", library.yaml_path]).stdout.decode().strip().split()
 
     @logEntryExit
     def vendor(self, library):

--- a/poetry.lock
+++ b/poetry.lock
@@ -175,6 +175,17 @@ rsa = ["cryptography"]
 
 [[package]]
 category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -264,7 +275,7 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [metadata]
-content-hash = "4b34dcf1abad3adac5f3063b1e71ef207c00d80ba74701fbea13ec3941457024"
+content-hash = "959a90c9bdfbadb498b718082c4642762468c8a32d1c62c81f13ae5741f45891"
 python-versions = "^3.5"
 
 [metadata.files]
@@ -406,8 +417,11 @@ pymysql = [
     {file = "PyMySQL-0.9.3-py2.py3-none-any.whl", hash = "sha256:3943fbbbc1e902f41daf7f9165519f140c4451c179380677e6a848587042561a"},
     {file = "PyMySQL-0.9.3.tar.gz", hash = "sha256:d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
 requests = [
-    {file = "requests-2.23.0-py2.7.egg", hash = "sha256:5d2d0ffbb515f39417009a46c14256291061ac01ba8f875b90cad137de83beb4"},
     {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
     {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ cryptography = "^2.9.2"
 codecov = "^2.1.3"
 sentry-sdk = "0.10.2"
 json-e = "^4.2.0"
+python-dateutil = "^2.8.1"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.2"

--- a/tests/bugzilla.py
+++ b/tests/bugzilla.py
@@ -39,7 +39,7 @@ class MockBugzillaServer(server.BaseHTTPRequestHandler):
                 'component': 'ImageLib',
                 'type': "enhancement",
                 'severity': "normal",
-                'summary': 'Update dav1d to new version V1',
+                'summary': 'Update dav1d to new version V1 from 2020-08-21 15:13:49',
                 'description': '',
                 'whiteboard': '[3pl-filed]',
                 'cc': ['tom@mozilla.com']
@@ -107,7 +107,7 @@ class TestBugzillaProvider(unittest.TestCase):
             'bugzilla_product': 'Core',
             'bugzilla_component': 'ImageLib',
         })
-        self.bugzillaProvider.file_bug(library, 'V1')
+        self.bugzillaProvider.file_bug(library, 'V1', '2020-08-21T15:13:49.000+02:00')
 
     def testComment(self):
         self.bugzillaProvider.comment_on_bug(

--- a/tests/functionality.py
+++ b/tests/functionality.py
@@ -92,7 +92,7 @@ class MockedBugzillaProvider(BaseProvider):
         self._filed_bug_id = config['filed_bug_id']
         pass
 
-    def file_bug(self, library, new_release_version):
+    def file_bug(self, library, new_release_version, release_timestamp):
         return self._filed_bug_id
 
     def comment_on_bug(self, bug_id, comment, needinfo=None, assignee=None):
@@ -147,7 +147,7 @@ class TestCommandRunner(unittest.TestCase):
         self.configs['Bugzilla']['filed_bug_id'] = expected_values.filed_bug_id
 
         command_mappings = {
-            "./mach vendor": expected_values.library_version_id,
+            "./mach vendor": expected_values.library_version_id + " 2020-08-21T15:13:49.000+02:00",
             "./mach try auto": TRY_OUTPUT(try_revision),
             "arc diff --verbatim": ARC_OUTPUT
         }


### PR DESCRIPTION
Small changes to `BugzillaProvider.file_bug` and `mach_vendor.py` to propagate timestamp info from mach.

Matching Bugzilla bug to support these changes is [1661021](https://bugzilla.mozilla.org/show_bug.cgi?id=1661021)