### PR TITLE
Add pr_comment.sh and store copy of shell output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             sudo apt-get install default-mysql-client
             mysql -h 127.0.0.1 -u username -pp4ssw0rd -e 'CREATE DATABASE IF NOT EXISTS updatebot;'
-          name: Install MySQL CLI; Create updatebot db and localconfig
+          name: Create updatebot database
       - save_cache:
           key: deps-{{ checksum "poetry.lock" }}
           paths:
@@ -65,8 +65,16 @@ jobs:
           name: Waiting for MySQL to be ready
       - run:
           command: |
+            sudo apt-get install jq
             cp localconfig.py.example localconfig.py
-            poetry run coverage run test.py
+            if COMMAND_OUTPUT=$(poetry run coverage run test.py 2>&1); then
+              echo $COMMAND_OUTPUT
+            else
+              echo $COMMAND_OUTPUT
+              COMMAND_OUTPUT=$(jq -nc --arg str "$COMMAND_OUTPUT" '$str')
+              . .circleci/pr_comment.sh
+              exit 1
+            fi
           name: test
       - run:
           command: poetry run codecov
@@ -83,7 +91,16 @@ jobs:
           command: poetry check
           name: dependencies
       - run:
-          command: poetry run flake8 --ignore=E501,E402 .
+          command: |
+            sudo apt-get install jq
+            if COMMAND_OUTPUT=$(poetry check && poetry run flake8 --ignore=E501,E402 . 2>&1); then
+              echo $COMMAND_OUTPUT
+            else
+              echo $COMMAND_OUTPUT
+              COMMAND_OUTPUT=$(jq -nc --arg str "$COMMAND_OUTPUT" '$str')
+              . .circleci/pr_comment.sh
+              exit 1
+            fi
           name: lint
 
   cleanup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           # COMMAND_OUTPUT ends up being stdout and stderr for the command run
           # and the if statement checks poetry's return value.
           #
-          # This insures that the pr_comment script is run regardless of if our
+          # This ensures that the pr_comment script is run regardless of if our
           # command fails.
           command: |
             sudo apt-get install jq
@@ -103,7 +103,7 @@ jobs:
           # COMMAND_OUTPUT ends up being stdout and stderr for the command run
           # and the if statement checks poetry's return value.
           #
-          # This insures that the pr_comment script is run regardless of if our
+          # This ensures that the pr_comment script is run regardless of if our
           # command fails.
           command: |
             sudo apt-get install jq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,13 @@ jobs:
             echo Failed waiting for MySQL && exit 1
           name: Waiting for MySQL to be ready
       - run:
+          # The if/else clause simulates a try/catch block in bash due to
+          # CircleCI halting as soon as any command returns a non-zero value.
+          # COMMAND_OUTPUT ends up being stdout and stderr for the command run
+          # and the if statement checks poetry's return value.
+          #
+          # This insures that the pr_comment script is run regardless of if our
+          # command fails.
           command: |
             sudo apt-get install jq
             cp localconfig.py.example localconfig.py
@@ -91,6 +98,13 @@ jobs:
           command: poetry check
           name: dependencies
       - run:
+          # The if/else clause simulates a try/catch block in bash due to
+          # CircleCI halting as soon as any command returns a non-zero value.
+          # COMMAND_OUTPUT ends up being stdout and stderr for the command run
+          # and the if statement checks poetry's return value.
+          #
+          # This insures that the pr_comment script is run regardless of if our
+          # command fails.
           command: |
             sudo apt-get install jq
             if COMMAND_OUTPUT=$(poetry check && poetry run flake8 --ignore=E501,E402 . 2>&1); then

--- a/.circleci/pr_comment.sh
+++ b/.circleci/pr_comment.sh
@@ -3,7 +3,7 @@
 if [ $CIRCLE_BRANCH != "master" ]
 then
   # extract PR number from CircleCI environment variable and append to API url
-  curl --request POST "https://api.github.com/repos/metalcanine/pythonci/issues/${CIRCLE_PULL_REQUEST##*/}/comments" \
+  curl --request POST "https://api.github.com/repos/mozilla-services/updatebot/issues/${CIRCLE_PULL_REQUEST##*/}/comments" \
   -u $GH_USER:$GH_TOKEN \
   --header 'Accept: application/vnd.github.v3+json' \
   --data-raw "{\"body\": ${COMMAND_OUTPUT}}"

--- a/.circleci/pr_comment.sh
+++ b/.circleci/pr_comment.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# restrict to running on non-main branches
+if [ $CIRCLE_BRANCH != "master" ]
+then
+  # extract PR number from CircleCI environment variable and append to API url
+  curl --request POST "https://api.github.com/repos/metalcanine/pythonci/issues/${CIRCLE_PULL_REQUEST##*/}/comments" \
+  -u $GH_USER:$GH_TOKEN \
+  --header 'Accept: application/vnd.github.v3+json' \
+  --data-raw "{\"body\": ${COMMAND_OUTPUT}}"
+fi


### PR DESCRIPTION
There are some parts of this that are kind of obtuse and having a separate shell script is annoying, but I think that's an okay trade off for not having to 
A) run a server somewhere that polls for CI failures or 
B) manually reconstruct AWS links for log downloads

I'll make the bot account for us (with access given to tjr, freddy, and myself) and create the access tokens in CircleCI once this is ready to merge.