### PR TITLE
Make the kill switch email an ‘error’ so we know it got disabled

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -131,7 +131,7 @@ class Updatebot:
     def run(self, library_filter=""):
         try:
             if not self.dbProvider.updatebot_is_enabled():
-                self.logger.log("Updatebot is disabled per the config database, not doing anything and ending execution.", level=LogLevel.Warning)
+                self.logger.log_exception(Exception("Updatebot is disabled per the config database, not doing anything and ending execution."))
                 return
 
             if 'gecko-path' in self.config_dictionary['General']:


### PR DESCRIPTION
Closes #96