### PR TITLE
Issue #119 - remove outgoing commits in between processing libraries

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -205,6 +205,9 @@ class Updatebot:
                         taskRunner = self.taskRunners[task.type]
                         taskRunner.process_task(lib, task)
                     except Exception as e:
+                        # Clean up any changes to the repo we may have made
+                        self.cmdProvider.run(["hg", "checkout", "-C", "."])
+                        self.cmdProvider.run(["hg", "purge", "."])
                         self.logger.log("Caught an exception while processing library %s task type %s" % (lib.name, task.type), level=LogLevel.Error)
                         self.logger.log_exception(e)
         except Exception as e:

--- a/tasktypes/vendoring.py
+++ b/tasktypes/vendoring.py
@@ -34,7 +34,12 @@ class VendorTaskRunner:
             self.logger.log("%s is a brand new revision to updatebot." % (new_version), level=LogLevel.Info)
             self._process_new_job(library, task, new_version, timestamp)
 
-        # TODO #119: We need to remove any commits we made so the repo is clean for the next library.
+        # remove commits generated from processing this library, will return success
+        # regardless of if outgoing commits exist or not.
+        self.logger.log("Removing any outgoing commits before moving on.", level=LogLevel.Info)
+
+        self.cmdProvider.run(["hg", "status"])  # hey what the fruck?
+        self.cmdProvider.run(["hg", "strip", "roots(outgoing())", "--no-backup"])
 
     # ====================================================================
 


### PR DESCRIPTION
Going to test this in holly to make sure it both doesn't blow up and that `hg strip` is available before requesting review