### PR TITLE
Fix a bug that came in from the spurious update feature

### DIFF
--- a/tasktypes/vendoring.py
+++ b/tasktypes/vendoring.py
@@ -179,9 +179,9 @@ class VendorTaskRunner(BaseTaskRunner):
             return
 
         # File the bug ----------------
-        bugzilla_id = self.bugzillaProvider.file_bug(library, CommentTemplates.UPDATE_SUMMARY(library, new_version, timestamp), CommentTemplates.UPDATE_DETAILS(len(all_upstream_commits), len(unseen_upstream_commits), commit_details), task.cc)
-        self.dbProvider.update_job_add_bug_id(created_job, bugzilla_id)
-        clean_up_old_job(old_job, bugzilla_id)
+        created_job.bugzilla_id = self.bugzillaProvider.file_bug(library, CommentTemplates.UPDATE_SUMMARY(library, new_version, timestamp), CommentTemplates.UPDATE_DETAILS(len(all_upstream_commits), len(unseen_upstream_commits), commit_details), task.cc)
+        self.dbProvider.update_job_add_bug_id(created_job, created_job.bugzilla_id)
+        clean_up_old_job(old_job, created_job.bugzilla_id)
 
         # Handle the other vendoring outcomes
         if result == VendorResult.GENERAL_ERROR:


### PR DESCRIPTION
Previously we passed in the bug id to create_job() which would
associate it with the returned job object.  We stopped doing that
so created_job did not have a bugzilla_id attached to it.  When you
tried to comment on a bug from it, it was zero and Bugzilla does not
like that.