### PR TITLE
If ./mach try times out because it couldn't get a lock, try 5 times

### DIFF
--- a/tests/functionality_all_platforms.py
+++ b/tests/functionality_all_platforms.py
@@ -28,7 +28,7 @@ from components.scmprovider import SCMProvider
 from apis.taskcluster import TaskclusterProvider
 from apis.phabricator import PhabricatorProvider
 
-from tests.functionality_utilities import SHARED_COMMAND_MAPPINGS, TRY_OUTPUT, CONDUIT_EDIT_OUTPUT, MockedBugzillaProvider, treeherder_response
+from tests.functionality_utilities import SHARED_COMMAND_MAPPINGS, TRY_OUTPUT, TRY_LOCKED_OUTPUT, CONDUIT_EDIT_OUTPUT, MockedBugzillaProvider, treeherder_response
 from tests.mock_commandprovider import TestCommandProvider
 from tests.mock_libraryprovider import MockLibraryProvider
 from tests.mock_treeherder_server import MockTreeherderServerFactory, TYPE_HEALTH
@@ -362,6 +362,62 @@ class TestFunctionality(SimpleLoggingTest):
             self.assertEqual(JOBSTATUS.DONE, j.status, "Expected status JOBSTATUS.DONE, got status %s" % (j.status.name))
             self.assertEqual(JOBOUTCOME.COULD_NOT_SUBMIT_TO_TRY, j.outcome, "Expected outcome JOBOUTCOME.COULD_NOT_SUBMIT_TO_TRY, got outcome %s" % (j.outcome.name))
             self.assertEqual(expected_values.get_filed_bug_id_func(), j.bugzilla_id)
+
+        finally:
+            self._cleanup(u, expected_values)
+
+    # Create -> ./mach vendor -> commit -> Fails during try submit after locking 5 times
+    @logEntryExitHeaderLine
+    def testFailsDuringTrySubmitLockedForever(self):
+        library_filter = 'dav1d'
+
+        (u, expected_values, _check_jobs) = self._setup(
+            library_filter,
+            lambda b: ["try_rev|2021-02-09 15:30:04 -0500|2021-02-12 17:40:01 +0000"],
+            lambda: 50,  # get_filed_bug_id_func,
+            lambda b: [],  # filed_bug_ids_func
+            AssertFalse,  # treeherder_response
+            command_callbacks={'try_submit': lambda: (1, TRY_LOCKED_OUTPUT)}
+        )
+        try:
+            u.run(library_filter=library_filter)
+
+            # Cannot use the provided _check_jobs
+            lib = [lib for lib in u.libraryProvider.get_libraries(u.config_dictionary['General']['gecko-path']) if library_filter in lib.name][0]
+            j = u.dbProvider.get_job(lib, expected_values.library_new_version_id())
+            self.assertEqual(expected_values.library_new_version_id(), j.version)
+            self.assertEqual(JOBSTATUS.DONE, j.status, "Expected status JOBSTATUS.DONE, got status %s" % (j.status.name))
+            self.assertEqual(JOBOUTCOME.COULD_NOT_SUBMIT_TO_TRY, j.outcome, "Expected outcome JOBOUTCOME.COULD_NOT_SUBMIT_TO_TRY, got outcome %s" % (j.outcome.name))
+            self.assertEqual(expected_values.get_filed_bug_id_func(), j.bugzilla_id)
+
+        finally:
+            self._cleanup(u, expected_values)
+
+    # Create -> ./mach vendor -> commit -> Fails during try submit
+    @logEntryExitHeaderLine
+    def testTryLockedOutput(self):
+        library_filter = 'dav1d'
+
+        call_counter = 0
+
+        def try_output():
+            nonlocal call_counter
+            if call_counter < 2:
+                call_counter += 1
+                return (1, TRY_LOCKED_OUTPUT)
+            return (0, TRY_OUTPUT(expected_values.try_revision_id()))
+
+        (u, expected_values, _check_jobs) = self._setup(
+            library_filter,
+            lambda b: ["try_rev|2021-02-09 15:30:04 -0500|2021-02-12 17:40:01 +0000"],
+            lambda: 50,  # get_filed_bug_id_func,
+            lambda b: [],  # filed_bug_ids_func
+            AssertFalse,  # treeherder_response
+            command_callbacks={'try_submit': try_output}
+        )
+        try:
+            u.run(library_filter=library_filter)
+            _check_jobs(JOBSTATUS.AWAITING_SECOND_PLATFORMS_TRY_RESULTS, JOBOUTCOME.PENDING)
 
         finally:
             self._cleanup(u, expected_values)

--- a/tests/functionality_utilities.py
+++ b/tests/functionality_utilities.py
@@ -31,6 +31,16 @@ Required Callbacks
 
 abandon         echo {\"transactions\": [{\"type\":\"abandon\"")
 patch           ./mach vendor --patch-mode only
+
+
+The callbacks MAY take a single parameter - if they do, they will receive
+a string containing the command that was to be executed.
+
+The callbacks MAY return either a string, or a tuple of (int, string).
+If it returns a tuple, the integer is interpetted as the returncode of the
+mocked execution, and the string as the standard output.
+If it returns a string, it is interpretted as the standard output and a
+returncode os 0 is used.
 """
 
 
@@ -110,6 +120,25 @@ temporary commit removed, repository restored
 """ % (revision, revision)
     return s
 
+
+TRY_LOCKED_OUTPUT = """
+Creating temporary commit for remote...
+A try_task_config.json
+pushing to ssh://hg.mozilla.org/try
+searching for changes
+remote: waiting for lock on working directory of /repo/hg/mozilla/try held by process '18116' on host 'hgssh1.dmz.mdc1.mozilla.com/effffffc'
+remote: abort: working directory of /repo/hg/mozilla/try: timed out waiting for lock held by 'hgssh1.dmz.mdc1.mozilla.com/effffffc:20282'
+temporary commit removed, repository restored
+Error running mach:
+
+    ['try', 'auto']
+
+The error occurred in code that was called by the mach command. This is either
+a bug in the called code itself or in the way that mach is calling it.
+You can invoke ``./mach busted`` to check if this issue is already on file. If it
+isn't, please use ``./mach busted file try`` to report it. If ``./mach busted`` is
+misbehaving, you can also inspect the dependencies of bug 1543241.
+"""
 
 ARC_OUTPUT = """
 Submitting 1 commit for review:


### PR DESCRIPTION
This patch introduces a new behavior for mocked process output that allows us to specify a returncode.

Fixes #319 