### PR TITLE
Add Support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         poetry-version: [1.1.0]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         poetry-version: [1.1.0]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/components/db.py
+++ b/components/db.py
@@ -115,29 +115,26 @@ INSERTION_QUERIES = [
     })
 ]
 
-for p in dir(JOBSTATUS):
-    if p[0] != '_':
-        INSERTION_QUERIES.append(
-            Struct(**{
-                'query': "INSERT INTO `status_types` (`id`, `name`) VALUES (%s, %s)",
-                'args': (getattr(JOBSTATUS, p), p)
-            }))
+for p in JOBSTATUS:
+    INSERTION_QUERIES.append(
+        Struct(**{
+            'query': "INSERT INTO `status_types` (`id`, `name`) VALUES (%s, %s)",
+            'args': (p, p.name)
+        }))
 
-for p in dir(JOBOUTCOME):
-    if p[0] != '_':
-        INSERTION_QUERIES.append(
-            Struct(**{
-                'query': "INSERT INTO `outcome_types` (`id`, `name`) VALUES (%s, %s)",
-                'args': (getattr(JOBOUTCOME, p), p)
-            }))
+for p in JOBOUTCOME:
+    INSERTION_QUERIES.append(
+        Struct(**{
+            'query': "INSERT INTO `outcome_types` (`id`, `name`) VALUES (%s, %s)",
+            'args': (p, p.name)
+        }))
 
-for p in dir(JOBTYPE):
-    if p[0] != '_':
-        INSERTION_QUERIES.append(
-            Struct(**{
-                'query': "INSERT INTO `job_types` (`id`, `name`) VALUES (%s, %s)",
-                'args': (getattr(JOBTYPE, p), p)
-            }))
+for p in JOBTYPE:
+    INSERTION_QUERIES.append(
+        Struct(**{
+            'query': "INSERT INTO `job_types` (`id`, `name`) VALUES (%s, %s)",
+            'args': (p, p.name)
+        }))
 # ==================================================================================
 
 


### PR DESCRIPTION
There seem to have been some changes to `IntEnum` that do not allow us to use `dir()` anymore for listing the enum keys. I get the following error when trying to run the tests:

```
pymysql.err.DataError: (1366, "Incorrect integer value: '<method 'as_integer_ratio' of 'int' objects>' for column 'id' at row 1")
```
It seems `as_integer_ratio` incorrectly gets picked up as a key of the enum. So switch to directly iterating the enums and accessing the `name` attribute instead. Also add Python 3.11 to the Github Workflow.