### PR TITLE
Improve logging to include library name and job id

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -223,6 +223,7 @@ class Updatebot:
                     continue
 
                 for task in lib.tasks:
+                    self.logger.set_context(lib.name)
                     try:
                         taskRunner = self.taskRunners[task.type]
 
@@ -234,6 +235,7 @@ class Updatebot:
                         reset_repository(self.cmdProvider)
                         self.logger.log("Caught an exception while processing library %s task type %s" % (lib.name, task.type), level=LogLevel.Error)
                         self.logger.log_exception(e)
+                    self.logger.clear_context()
         except Exception as e:
             self.logger.log_exception(e)
             raise(e)

--- a/tasktypes/commitalert.py
+++ b/tasktypes/commitalert.py
@@ -43,6 +43,7 @@ class CommitAlertTaskRunner(BaseTaskRunner):
         jobs_with_open_bugs = [j for j in all_library_jobs if j.bugzilla_id in open_bugs]
         self.logger.log("We need to potentially update the FF version on %s open bugs." % len(open_bugs), level=LogLevel.Info)
         for j in jobs_with_open_bugs:
+            self.logger.set_context(library.name, j.id)
             if my_ff_version not in j.ff_versions:
                 is_affected = _contains_commit(all_upstream_commits, j.version)
                 self.logger.log("Updating bug %s to set FF version %s as %s." % (
@@ -50,6 +51,7 @@ class CommitAlertTaskRunner(BaseTaskRunner):
                 self.bugzillaProvider.mark_ff_version_affected(j.bugzilla_id, my_ff_version, affected=is_affected)
                 j.ff_versions.add(my_ff_version)
                 self.dbProvider.update_job_ff_versions(j, my_ff_version)
+        self.logger.set_context(library.name)
 
         # ==========================================================================================
         if not unseen_upstream_commits:
@@ -60,6 +62,8 @@ class CommitAlertTaskRunner(BaseTaskRunner):
         newest_commit = unseen_upstream_commits[-1]
         existing_job = self.dbProvider.get_job(library, newest_commit.revision)
         if existing_job:
+            self.logger.set_context(library.name, existing_job.id)
+
             if my_ff_version in existing_job.ff_versions:
                 # We've already seen this revision, and we've already associated it with this FF version
                 self.logger.log("We found a job with id %s for revision %s that was already processed for this ff version (%s)." % (

--- a/tasktypes/vendoring.py
+++ b/tasktypes/vendoring.py
@@ -40,9 +40,11 @@ class VendorTaskRunner(BaseTaskRunner):
 
         # Then process all of them
         for j in all_jobs_not_done:
+            self.logger.set_context(library.name, j.id)
             self.logger.log("Processing job id %s for %s which is currently %s and has a %s bug" % (j.id, library.name, j.status, "open" if j.bugzilla_is_open else "closed"))
             self._process_existing_job(library, task, j)
             self._reset_for_new_job()
+        self.logger.set_context(library.name)
 
         # See if we have a new upstream commit to process
         new_version, timestamp = self.vendorProvider.check_for_update(library)
@@ -103,6 +105,7 @@ class VendorTaskRunner(BaseTaskRunner):
 
         # Create the job ----------------------
         created_job = self.dbProvider.create_job(JOBTYPE.VENDORING, library, new_version, JOBSTATUS.CREATED, JOBOUTCOME.PENDING)
+        self.logger.set_context(library.name, created_job.id)
 
         # File the bug ------------------------
         all_upstream_commits, unseen_upstream_commits = self.scmProvider.check_for_update(library, task, new_version, most_recent_job)


### PR DESCRIPTION
Closes #347

Due to the way each provider has its own logging provider, I was only able to implement the proposed "context" as one global value. That means every logging provider shares the same context, but I think that is exactly want we want.