### PR TITLE
Re-raise KeyError in `findOpenBugs` with unexpected JSON

### DIFF
--- a/apis/bugzilla_api.py
+++ b/apis/bugzilla_api.py
@@ -156,7 +156,10 @@ def findOpenBugs(url, bugIDs):
     except Exception as e:
         raise Exception("Could not decode a bugzilla response as JSON: " + r.text) from e
 
-    return [b['id'] for b in j['bugs']]
+    try:
+        return [b['id'] for b in j['bugs']]
+    except KeyError as e:
+        raise Exception(j) from e
 
 
 def markFFVersionAffected(url, apikey, bugID, ff_version, affected):


### PR DESCRIPTION
This way we can take a look at the bad response next time we get a key error.

See #363