### PR TITLE
Do not populate commit details for libraries that won't need them.

### DIFF
--- a/components/libraryprovider.py
+++ b/components/libraryprovider.py
@@ -53,6 +53,7 @@ class Library:
         self.fuzzy_paths = dict.get('fuzzy_paths', None)
         self.yaml_path = dict['yaml_path']
         self.tasks = []
+        self.should_show_commit_details = self.name != 'irregexp' and self.flavor != 'individual-files'
 
         for t in dict['tasks']:
             self.tasks.append(Task(t))

--- a/components/scmprovider.py
+++ b/components/scmprovider.py
@@ -200,8 +200,9 @@ class SCMProvider(BaseProvider, INeedsCommandProvider, INeedsLoggingProvider):
                 unseen_new_upstream_commits = all_new_upstream_commits
 
             # Step 7: Populate the lists with additional details about the commits
-            [c.populate_details(library.repo_url, self.run) for c in unseen_new_upstream_commits]
-            [c.populate_details(library.repo_url, self.run) for c in all_new_upstream_commits]
+            if library.should_show_commit_details:
+                [c.populate_details(library.repo_url, self.run) for c in unseen_new_upstream_commits]
+                [c.populate_details(library.repo_url, self.run) for c in all_new_upstream_commits]
 
         finally:
             # Step 8 Return us to the origin directory
@@ -247,6 +248,9 @@ class SCMProvider(BaseProvider, INeedsCommandProvider, INeedsLoggingProvider):
 
             s = "----------------------------------------\n"
             for c in list_of_commits:
+                if not c.populated:
+                    raise Exception("Tried to build bug description; but commit details not populated.")
+
                 s += "%s by %s\n" % (c.revision, c.author)
                 s += c.revision_link + "\n"
 

--- a/tasktypes/vendoring.py
+++ b/tasktypes/vendoring.py
@@ -130,7 +130,7 @@ class VendorTaskRunner(BaseTaskRunner):
         # File the bug ------------------------
         all_upstream_commits, unseen_upstream_commits = self.scmProvider.check_for_update(library, task, new_version, most_recent_job)
         commit_stats = self.mercurialProvider.diff_stats()
-        commit_details = self.scmProvider.build_bug_description(all_upstream_commits, 65534 - len(commit_stats) - 220) if (library.name != 'irregexp' and library.flavor != 'individual-files') else ""
+        commit_details = self.scmProvider.build_bug_description(all_upstream_commits, 65534 - len(commit_stats) - 220) if library.should_show_commit_details else ""
 
         created_job.bugzilla_id = self.bugzillaProvider.file_bug(library, CommentTemplates.UPDATE_SUMMARY(library, new_version, timestamp), CommentTemplates.UPDATE_DETAILS(len(all_upstream_commits), len(unseen_upstream_commits), commit_stats, commit_details), task.cc, blocks=task.blocking)
         self.dbProvider.update_job_add_bug_id(created_job, created_job.bugzilla_id)


### PR DESCRIPTION
See also #385 but I'm not tackling that right now.