### PR TITLE
Use requests' json argument when passing JSON to the taskcluster API

### DIFF
--- a/apis/taskcluster.py
+++ b/apis/taskcluster.py
@@ -5,7 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from enum import unique, IntEnum
-import json
 import jsone
 import platform
 import requests
@@ -442,13 +441,12 @@ class TaskclusterProvider(BaseProvider, INeedsCommandProvider, INeedsLoggingProv
             template = retrigger_action['hookPayload']
 
             payload = jsone.render(template, context)
-            payload = json.dumps(payload).replace("\\n", " ")
 
             trigger_url = self.url_taskcluster + "api/hooks/v1/hooks/%s/%s/trigger" % \
                 (quote_plus(retrigger_action["hookGroupId"]), quote_plus(retrigger_action["hookId"]))
 
             self.logger.log("Issuing a retrigger to %s" % (trigger_url), level=LogLevel.Info)
-            r = requests.post(trigger_url, data=payload)
+            r = requests.post(trigger_url, json=payload)
             try:
                 if r.status_code == 200:
                     output = r.json()


### PR DESCRIPTION
When triggering hooks, the previous code was serializing the JSON itself then passing it straight to taskcluster as a string with no content type. This currently works because the taskcluster proxy has a workaround (see https://github.com/taskcluster/taskcluster/issues/3521) that sets the content type to application/json if it's missing from a request with a non empty body. This means that if that workaround was ever removed or if this script tries to target taskcluster directly without the proxy, the request would fail. Just use `requests.post(json=` and get serialization and the header for free.

The manual json.dumps() and the \n to space replace were leftovers from when the payload was shelled out through `echo -n '...' | taskcluster-darwin-amd64` in the past, where embedded newlines broke the quoted shell string.