### PR TITLE
Parse moz.yaml task 'options' into Task.options dict

### DIFF
--- a/.github/gecko-test/libcubeb-path/moz.yaml
+++ b/.github/gecko-test/libcubeb-path/moz.yaml
@@ -35,3 +35,4 @@ updatebot:
     - type: vendoring
       enabled: True
       blocking: 1234
+      options: ["one", "two"]

--- a/components/libraryprovider.py
+++ b/components/libraryprovider.py
@@ -105,6 +105,8 @@ class Task:
         self.frequency = dict['frequency']
         self.platform = dict['platform']
         self.blocking = dict['blocking']
+        # Each option named in the moz.yaml is stored as a key set to True.
+        self.options = {option: True for option in dict['options']}
 
         if self.type == 'commit-alert':
             self.filter = dict['filter']
@@ -298,6 +300,7 @@ class LibraryProvider(BaseProvider, INeedsCommandProvider, INeedsLoggingProvider
         validated_task['needinfo'] = get_key_or_default('needinfo', task_dict, [])
         validated_task['frequency'] = get_key_or_default('frequency', task_dict, 'every')
         validated_task['blocking'] = get_key_or_default('blocking', task_dict, None)
+        validated_task['options'] = get_key_or_default('options', task_dict, [])
 
         if validated_task['platform'] not in ('windows', 'linux'):
             raise AttributeError('library {0} task has an invalid value for a platform: {1}'.format(library_name, validated_task['platform']))

--- a/tests/library.py
+++ b/tests/library.py
@@ -72,7 +72,8 @@ LIBRARIES = [
                     LibraryProvider.validate_task({
                         'type': "vendoring",
                         'enabled': True,
-                        'blocking': '1234'
+                        'blocking': '1234',
+                        'options': ['one', 'two']
                     }, "n/a")
         ],
         "yaml_path": ".github/gecko-test/libcubeb-path/moz.yaml".replace("/", os.path.sep)


### PR DESCRIPTION
The moz.yaml vendoring/commit-alert task schema now accepts an 'options' array of strings. Capture it in validate_task (defaulting to an empty list) and expose it on Task as an 'options' dict where every value listed in the moz.yaml maps to True (an unspecified/empty list yields {}).

Also cover this in the libraryprovider test: the cubeb-path moz.yaml fixture gains an 'options' array and the matching expected Library is updated, so testLibraryFindAndImport exercises options flowing through get_libraries() into the Task.options dict.

Goes along with https://bugzilla.mozilla.org/show_bug.cgi?id=2050952